### PR TITLE
feat: Add email flag support for read/unread and flagged status filte…

### DIFF
--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -63,6 +63,17 @@ async def page_email(
         Literal["asc", "desc"],
         Field(default=None, description="Order emails by field. `asc` or `desc`."),
     ] = "desc",
+    is_unread: Annotated[
+        bool | None,
+        Field(default=None, description="Filter emails by read status. True for unread, False for read, None for all."),
+    ] = None,
+    is_flagged: Annotated[
+        bool | None,
+        Field(
+            default=None,
+            description="Filter emails by flagged status. True for flagged, False for unflagged, None for all.",
+        ),
+    ] = None,
 ) -> EmailPageResponse:
     handler = dispatch_handler(account_name)
 
@@ -77,6 +88,8 @@ async def page_email(
         from_address=from_address,
         to_address=to_address,
         order=order,
+        is_unread=is_unread,
+        is_flagged=is_flagged,
     )
 
 

--- a/mcp_email_server/emails/__init__.py
+++ b/mcp_email_server/emails/__init__.py
@@ -20,6 +20,8 @@ class EmailHandler(abc.ABC):
         from_address: str | None = None,
         to_address: str | None = None,
         order: str = "desc",
+        is_unread: bool | None = None,
+        is_flagged: bool | None = None,
     ) -> "EmailPageResponse":
         """
         Get emails

--- a/mcp_email_server/emails/models.py
+++ b/mcp_email_server/emails/models.py
@@ -10,6 +10,14 @@ class EmailData(BaseModel):
     body: str
     date: datetime
     attachments: list[str]
+    # IMAP flags
+    is_read: bool = False  # \Seen flag
+    is_answered: bool = False  # \Answered flag
+    is_flagged: bool = False  # \Flagged flag
+    is_deleted: bool = False  # \Deleted flag
+    is_draft: bool = False  # \Draft flag
+    is_recent: bool = False  # \Recent flag
+    flags: list[str] = []  # Raw flags from IMAP
 
     @classmethod
     def from_email(cls, email: dict[str, Any]):
@@ -19,6 +27,13 @@ class EmailData(BaseModel):
             body=email["body"],
             date=email["date"],
             attachments=email["attachments"],
+            is_read=email.get("is_read", False),
+            is_answered=email.get("is_answered", False),
+            is_flagged=email.get("is_flagged", False),
+            is_deleted=email.get("is_deleted", False),
+            is_draft=email.get("is_draft", False),
+            is_recent=email.get("is_recent", False),
+            flags=email.get("flags", []),
         )
 
 

--- a/tests/test_classic_handler.py
+++ b/tests/test_classic_handler.py
@@ -106,9 +106,11 @@ class TestClassicEmailHandler:
 
                 # Verify the client methods were called correctly
                 classic_handler.incoming_client.get_emails_stream.assert_called_once_with(
-                    1, 10, now, None, "Test", None, None, "sender@example.com", None, "desc"
+                    1, 10, now, None, "Test", None, None, "sender@example.com", None, "desc", None, None
                 )
-                mock_count.assert_called_once_with(now, None, "Test", None, None, "sender@example.com", None)
+                mock_count.assert_called_once_with(
+                    now, None, "Test", None, None, "sender@example.com", None, None, None
+                )
 
     @pytest.mark.asyncio
     async def test_send_email(self, classic_handler):

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -160,6 +160,8 @@ class TestMcpTools:
                 from_address="sender@example.com",
                 to_address=None,
                 order="desc",
+                is_unread=None,
+                is_flagged=None,
             )
 
     @pytest.mark.asyncio

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -19,6 +19,14 @@ class TestEmailData:
         assert email_data.body == "Test Body"
         assert isinstance(email_data.date, datetime)
         assert email_data.attachments == ["file1.txt", "file2.pdf"]
+        # Check default flag values
+        assert email_data.is_read is False
+        assert email_data.is_answered is False
+        assert email_data.is_flagged is False
+        assert email_data.is_deleted is False
+        assert email_data.is_draft is False
+        assert email_data.is_recent is False
+        assert email_data.flags == []
 
     def test_from_email(self):
         """Test from_email class method."""
@@ -38,6 +46,42 @@ class TestEmailData:
         assert email_data.body == "Test Body"
         assert email_data.date == now
         assert email_data.attachments == ["file1.txt", "file2.pdf"]
+        # Check default flag values
+        assert email_data.is_read is False
+        assert email_data.is_answered is False
+        assert email_data.is_flagged is False
+        assert email_data.is_deleted is False
+        assert email_data.is_draft is False
+        assert email_data.is_recent is False
+        assert email_data.flags == []
+
+    def test_from_email_with_flags(self):
+        """Test from_email with flag data."""
+        now = datetime.now()
+        email_dict = {
+            "subject": "Test Subject",
+            "from": "test@example.com",
+            "body": "Test Body",
+            "date": now,
+            "attachments": [],
+            "is_read": True,
+            "is_answered": True,
+            "is_flagged": False,
+            "is_deleted": False,
+            "is_draft": False,
+            "is_recent": True,
+            "flags": ["\\Seen", "\\Answered", "\\Recent"],
+        }
+
+        email_data = EmailData.from_email(email_dict)
+
+        assert email_data.is_read is True
+        assert email_data.is_answered is True
+        assert email_data.is_flagged is False
+        assert email_data.is_deleted is False
+        assert email_data.is_draft is False
+        assert email_data.is_recent is True
+        assert email_data.flags == ["\\Seen", "\\Answered", "\\Recent"]
 
 
 class TestEmailPageResponse:


### PR DESCRIPTION
- Add IMAP flag fields to EmailData model (is_read, is_flagged, etc.)
- Implement flag extraction from IMAP FETCH responses
- Add is_unread and is_flagged search parameters to filter emails
- Use BODY.PEEK[] to fetch emails without marking them as read
- Update tests to cover flag functionality

🤖 Generated with [Claude Code](https://claude.ai/code)